### PR TITLE
feat: fixed sql errors through sqlx's macros

### DIFF
--- a/identity/.sqlx/query-0530a188620679274bc385a86cf6c299b319fabd340cf982e7395ed5e3998649.json
+++ b/identity/.sqlx/query-0530a188620679274bc385a86cf6c299b319fabd340cf982e7395ed5e3998649.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO pastoral_role (\n                id, \n                name, \n                description,\n                weight\n            ) VALUES (\n                $1,\n                $2,\n                $3,\n                $4\n            ) \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0530a188620679274bc385a86cf6c299b319fabd340cf982e7395ed5e3998649"
+}

--- a/identity/.sqlx/query-053aad28d4f728a95800e90d9ba077ff10f354dde564bf3abd08f00cd41072e1.json
+++ b/identity/.sqlx/query-053aad28d4f728a95800e90d9ba077ff10f354dde564bf3abd08f00cd41072e1.json
@@ -1,0 +1,126 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO \"satellite\" (\n                id,\n                no,\n                name,\n                address\n            ) VALUES (\n                $1,\n                $2,\n                $3,\n                $4\n            )\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4",
+        "Text",
+        {
+          "Custom": {
+            "name": "address",
+            "kind": {
+              "Domain": {
+                "Custom": {
+                  "name": "_address",
+                  "kind": {
+                    "Composite": [
+                      [
+                        "line_one",
+                        "Text"
+                      ],
+                      [
+                        "line_two",
+                        "Text"
+                      ],
+                      [
+                        "city",
+                        "Text"
+                      ],
+                      [
+                        "state",
+                        "Text"
+                      ],
+                      [
+                        "country",
+                        "Text"
+                      ],
+                      [
+                        "postal_code",
+                        "Text"
+                      ]
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "053aad28d4f728a95800e90d9ba077ff10f354dde564bf3abd08f00cd41072e1"
+}

--- a/identity/.sqlx/query-0cd6f6114cb592be2d88e18a2b4fdc92c282a8b4725060921a788d1b8c4e73cb.json
+++ b/identity/.sqlx/query-0cd6f6114cb592be2d88e18a2b4fdc92c282a8b4725060921a788d1b8c4e73cb.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT \n                m.* \n            FROM \n                ministry m \n                    INNER JOIN user_ministry um ON m.id = um.ministry_id\n            WHERE um.user_id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "department_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "team_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0cd6f6114cb592be2d88e18a2b4fdc92c282a8b4725060921a788d1b8c4e73cb"
+}

--- a/identity/.sqlx/query-11f867e72f91fb08fa36bc7a7e83cc7b55e2bfcadf6360538e69e3ec4702c8c1.json
+++ b/identity/.sqlx/query-11f867e72f91fb08fa36bc7a7e83cc7b55e2bfcadf6360538e69e3ec4702c8c1.json
@@ -1,0 +1,166 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT \n                u.* \n            FROM \n                user_ministry um\n                    INNER JOIN \"user\" u ON um.user_id = u.id\n            WHERE um.ministry_id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "email_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "username",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "given_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "family_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "gender",
+        "type_info": {
+          "Custom": {
+            "name": "gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "ic_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "phone_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "phone_number_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "nickname",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 15,
+        "name": "date_of_birth",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "11f867e72f91fb08fa36bc7a7e83cc7b55e2bfcadf6360538e69e3ec4702c8c1"
+}

--- a/identity/.sqlx/query-12f3baaa985ae90a06632e0f0ca7701657524eebc3f4bc7fae76f77fa7ed3df3.json
+++ b/identity/.sqlx/query-12f3baaa985ae90a06632e0f0ca7701657524eebc3f4bc7fae76f77fa7ed3df3.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from ministry WHERE id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "department_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "team_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "12f3baaa985ae90a06632e0f0ca7701657524eebc3f4bc7fae76f77fa7ed3df3"
+}

--- a/identity/.sqlx/query-15282d342e8aaa904c4c5e16d7849b2ae3ebe5cbebde6ef42b7837115acdbf1d.json
+++ b/identity/.sqlx/query-15282d342e8aaa904c4c5e16d7849b2ae3ebe5cbebde6ef42b7837115acdbf1d.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM ministry_team \n            WHERE id = $1::TEXT \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "15282d342e8aaa904c4c5e16d7849b2ae3ebe5cbebde6ef42b7837115acdbf1d"
+}

--- a/identity/.sqlx/query-1e3c1f0550de4709f43b6c09ece48233b522568949a8d8c1d9c2b8c4f1ead8e0.json
+++ b/identity/.sqlx/query-1e3c1f0550de4709f43b6c09ece48233b522568949a8d8c1d9c2b8c4f1ead8e0.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT \n                pr.* \n            FROM \n                pastoral_role pr \n                    INNER JOIN user_connect_group ucg ON pr.id = ucg.user_role\n            WHERE ucg.user_id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "1e3c1f0550de4709f43b6c09ece48233b522568949a8d8c1d9c2b8c4f1ead8e0"
+}

--- a/identity/.sqlx/query-228a0cf43116b8d179ff8b9461ab70157e64e379ea3102c88d321900ab540097.json
+++ b/identity/.sqlx/query-228a0cf43116b8d179ff8b9461ab70157e64e379ea3102c88d321900ab540097.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM \n                user_connect_group ucg\n            WHERE \n                ucg.connect_group_id = $1::TEXT\n                    AND ucg.user_id = ANY($2::TEXT[])\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "228a0cf43116b8d179ff8b9461ab70157e64e379ea3102c88d321900ab540097"
+}

--- a/identity/.sqlx/query-26e8da6ad3df7669d3eeb7236470a125a5373634ed183ce0542132aadd8dd1dd.json
+++ b/identity/.sqlx/query-26e8da6ad3df7669d3eeb7236470a125a5373634ed183ce0542132aadd8dd1dd.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from ministry_department WHERE id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "26e8da6ad3df7669d3eeb7236470a125a5373634ed183ce0542132aadd8dd1dd"
+}

--- a/identity/.sqlx/query-2dd289c5791601cbd052e3fbb89a13fa25fb85960d713314052907af606e38ed.json
+++ b/identity/.sqlx/query-2dd289c5791601cbd052e3fbb89a13fa25fb85960d713314052907af606e38ed.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from connect_group WHERE id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "variant",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2dd289c5791601cbd052e3fbb89a13fa25fb85960d713314052907af606e38ed"
+}

--- a/identity/.sqlx/query-36c70c79b88d9dbe794149b57095b567ac285ae409338c9e645e82c140042713.json
+++ b/identity/.sqlx/query-36c70c79b88d9dbe794149b57095b567ac285ae409338c9e645e82c140042713.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT \n                cg.* \n            FROM \n                connect_group cg \n                    INNER JOIN user_connect_group ucg ON cg.id = ucg.connect_group_id\n            WHERE ucg.user_id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "variant",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "36c70c79b88d9dbe794149b57095b567ac285ae409338c9e645e82c140042713"
+}

--- a/identity/.sqlx/query-3a36f81d91954aad772e3eb07334c6fc349eed347ba5faf79a4c195054957596.json
+++ b/identity/.sqlx/query-3a36f81d91954aad772e3eb07334c6fc349eed347ba5faf79a4c195054957596.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO connect_group (\n                id, \n                name, \n                no,\n                variant, \n                satellite_id\n            ) VALUES (\n                $1,\n                $2,\n                $3,\n                $4,\n                $5\n            ) \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "variant",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int4",
+        "Bpchar",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3a36f81d91954aad772e3eb07334c6fc349eed347ba5faf79a4c195054957596"
+}

--- a/identity/.sqlx/query-3c413b70a1ed4b6d024d60ae56517a726297cd61210431d74959753dd6725230.json
+++ b/identity/.sqlx/query-3c413b70a1ed4b6d024d60ae56517a726297cd61210431d74959753dd6725230.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM ministry \n            WHERE id = $1::TEXT \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "department_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "team_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3c413b70a1ed4b6d024d60ae56517a726297cd61210431d74959753dd6725230"
+}

--- a/identity/.sqlx/query-43f29f25bec369555e120fe027697dbed110b249adf55d40e5f82d82e2faf81f.json
+++ b/identity/.sqlx/query-43f29f25bec369555e120fe027697dbed110b249adf55d40e5f82d82e2faf81f.json
@@ -1,0 +1,84 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from \"satellite\"\n            WHERE id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "43f29f25bec369555e120fe027697dbed110b249adf55d40e5f82d82e2faf81f"
+}

--- a/identity/.sqlx/query-4ad40e1ba4f2d03bdfdcaa846922c7129abf741a48836abc18f1d7b3829540b5.json
+++ b/identity/.sqlx/query-4ad40e1ba4f2d03bdfdcaa846922c7129abf741a48836abc18f1d7b3829540b5.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE ministry_team SET\n                name        = COALESCE($1, name),\n                description = COALESCE($2, description),\n                updated_at  = NOW()\n            WHERE id = $3\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4ad40e1ba4f2d03bdfdcaa846922c7129abf741a48836abc18f1d7b3829540b5"
+}

--- a/identity/.sqlx/query-4c53afdae28aadf4cfff1e1bc9492a403df6c68adbf8c08eacb66cb6b67cb2ba.json
+++ b/identity/.sqlx/query-4c53afdae28aadf4cfff1e1bc9492a403df6c68adbf8c08eacb66cb6b67cb2ba.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT \n                mr.* \n            FROM \n                ministry_role mr \n                    INNER JOIN user_ministry um ON mr.id = um.user_role\n            WHERE um.user_id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4c53afdae28aadf4cfff1e1bc9492a403df6c68adbf8c08eacb66cb6b67cb2ba"
+}

--- a/identity/.sqlx/query-4c7d745e771015953f59e40c48c4eaa903f0e37f68d8863204222d65da817036.json
+++ b/identity/.sqlx/query-4c7d745e771015953f59e40c48c4eaa903f0e37f68d8863204222d65da817036.json
@@ -1,0 +1,164 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from \"user\"\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "email_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "username",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "given_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "family_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "gender",
+        "type_info": {
+          "Custom": {
+            "name": "gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "ic_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "phone_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "phone_number_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "nickname",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 15,
+        "name": "date_of_birth",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "4c7d745e771015953f59e40c48c4eaa903f0e37f68d8863204222d65da817036"
+}

--- a/identity/.sqlx/query-4d2fb86eae90d56ead346596e235ee9dc77b9fd493c8c84685307577efb67c69.json
+++ b/identity/.sqlx/query-4d2fb86eae90d56ead346596e235ee9dc77b9fd493c8c84685307577efb67c69.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from pastoral_role\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4d2fb86eae90d56ead346596e235ee9dc77b9fd493c8c84685307577efb67c69"
+}

--- a/identity/.sqlx/query-5a82ad70021f65317a5a2778b54325124393031cb388081aa4250414d4a05e48.json
+++ b/identity/.sqlx/query-5a82ad70021f65317a5a2778b54325124393031cb388081aa4250414d4a05e48.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM pastoral_role \n            WHERE id = $1::TEXT \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5a82ad70021f65317a5a2778b54325124393031cb388081aa4250414d4a05e48"
+}

--- a/identity/.sqlx/query-5e1de284dca7e6eac4cc188113d04d13f8755d79dd17c13b83fe392add8a19ae.json
+++ b/identity/.sqlx/query-5e1de284dca7e6eac4cc188113d04d13f8755d79dd17c13b83fe392add8a19ae.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO ministry_department (\n                id, \n                name,\n                description\n            ) VALUES (\n                $1,\n                $2,\n                $3\n            ) \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5e1de284dca7e6eac4cc188113d04d13f8755d79dd17c13b83fe392add8a19ae"
+}

--- a/identity/.sqlx/query-5f2aced67474281efca534a29270c07fe466291cf1d775570c2ab08fa8106ef1.json
+++ b/identity/.sqlx/query-5f2aced67474281efca534a29270c07fe466291cf1d775570c2ab08fa8106ef1.json
@@ -1,0 +1,69 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE ministry SET\n                name          = COALESCE($1, name),\n                description   = COALESCE($2, description),\n                department_id = COALESCE($3, department_id),\n                team_id       = COALESCE($4, team_id),\n                satellite_id  = COALESCE($5, satellite_id),\n                updated_at    = NOW()\n            WHERE id = $6\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "department_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "team_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5f2aced67474281efca534a29270c07fe466291cf1d775570c2ab08fa8106ef1"
+}

--- a/identity/.sqlx/query-5f395d7fae240dd5034266deed3931e730cf0b519708c78e12abc1807c3ec3a6.json
+++ b/identity/.sqlx/query-5f395d7fae240dd5034266deed3931e730cf0b519708c78e12abc1807c3ec3a6.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from ministry_role\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5f395d7fae240dd5034266deed3931e730cf0b519708c78e12abc1807c3ec3a6"
+}

--- a/identity/.sqlx/query-6072f1399303721c31517fb66b144d1a3309c16651ca2e1e41b3932724346574.json
+++ b/identity/.sqlx/query-6072f1399303721c31517fb66b144d1a3309c16651ca2e1e41b3932724346574.json
@@ -1,0 +1,166 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from \"user\" WHERE id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "email_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "username",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "given_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "family_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "gender",
+        "type_info": {
+          "Custom": {
+            "name": "gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "ic_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "phone_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "phone_number_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "nickname",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 15,
+        "name": "date_of_birth",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "6072f1399303721c31517fb66b144d1a3309c16651ca2e1e41b3932724346574"
+}

--- a/identity/.sqlx/query-61d1dce808bad537fbef67001c62011183d9c997d4ec588414b00251bfe633b4.json
+++ b/identity/.sqlx/query-61d1dce808bad537fbef67001c62011183d9c997d4ec588414b00251bfe633b4.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM ministry_department \n            WHERE id = $1::TEXT \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "61d1dce808bad537fbef67001c62011183d9c997d4ec588414b00251bfe633b4"
+}

--- a/identity/.sqlx/query-635067293e6257b406fa9d8cd4772e31ba8dc2ad4c1c992a2d401e3a38828206.json
+++ b/identity/.sqlx/query-635067293e6257b406fa9d8cd4772e31ba8dc2ad4c1c992a2d401e3a38828206.json
@@ -1,0 +1,222 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE \"user\" SET  \n                name                  = COALESCE($1, name),\n                email                 = COALESCE($2, email), \n                email_verified        = COALESCE($3, email_verified),\n                username              = COALESCE($4, username),\n                given_name            = COALESCE($5, given_name),\n                family_name           = COALESCE($6, family_name),\n                gender                = COALESCE($7, gender), \n                ic_number             = COALESCE($8, ic_number), \n                phone_number          = COALESCE($9, phone_number), \n                phone_number_verified = COALESCE($10, phone_number_verified), \n                nickname              = COALESCE($11, nickname),\n                avatar_url            = COALESCE($12, avatar_url),\n                address               = COALESCE($13, address),\n                date_of_birth         = COALESCE($14, date_of_birth),\n                updated_at            = NOW()\n            WHERE id = $15\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "email_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "username",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "given_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "family_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "gender",
+        "type_info": {
+          "Custom": {
+            "name": "gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "ic_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "phone_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "phone_number_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "nickname",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 15,
+        "name": "date_of_birth",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Bool",
+        "Text",
+        "Text",
+        "Text",
+        {
+          "Custom": {
+            "name": "gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female"
+              ]
+            }
+          }
+        },
+        "Text",
+        "Text",
+        "Bool",
+        "Text",
+        "Text",
+        {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        },
+        "Timestamptz",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "635067293e6257b406fa9d8cd4772e31ba8dc2ad4c1c992a2d401e3a38828206"
+}

--- a/identity/.sqlx/query-717f6c23a481cc807a2aaf42b4af84dafff1b66b1cdc9668604394b1b0b50a01.json
+++ b/identity/.sqlx/query-717f6c23a481cc807a2aaf42b4af84dafff1b66b1cdc9668604394b1b0b50a01.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from ministry_department\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "717f6c23a481cc807a2aaf42b4af84dafff1b66b1cdc9668604394b1b0b50a01"
+}

--- a/identity/.sqlx/query-7488064db8a284433bacd24bcafd277ec117c58f3171d265cabb8533e7f5a4b1.json
+++ b/identity/.sqlx/query-7488064db8a284433bacd24bcafd277ec117c58f3171d265cabb8533e7f5a4b1.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from ministry_team\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7488064db8a284433bacd24bcafd277ec117c58f3171d265cabb8533e7f5a4b1"
+}

--- a/identity/.sqlx/query-7c3acd974125a77af93f6654e3654c6e20a5406413b7c94d61af00c1bcb8e077.json
+++ b/identity/.sqlx/query-7c3acd974125a77af93f6654e3654c6e20a5406413b7c94d61af00c1bcb8e077.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM ministry_role \n            WHERE id = $1::TEXT \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7c3acd974125a77af93f6654e3654c6e20a5406413b7c94d61af00c1bcb8e077"
+}

--- a/identity/.sqlx/query-7e641eaa086cb3d808fc32c7db245b360fb6222a18a465bf31142eba37eb5ed4.json
+++ b/identity/.sqlx/query-7e641eaa086cb3d808fc32c7db245b360fb6222a18a465bf31142eba37eb5ed4.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from ministry\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "department_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "team_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7e641eaa086cb3d808fc32c7db245b360fb6222a18a465bf31142eba37eb5ed4"
+}

--- a/identity/.sqlx/query-9613e19c394f0ee76ec29810c46fcbe6c53ba6b3ce03de5e213ab9be2ffde71e.json
+++ b/identity/.sqlx/query-9613e19c394f0ee76ec29810c46fcbe6c53ba6b3ce03de5e213ab9be2ffde71e.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from pastoral_role WHERE id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9613e19c394f0ee76ec29810c46fcbe6c53ba6b3ce03de5e213ab9be2ffde71e"
+}

--- a/identity/.sqlx/query-9640c3953941915abca30063e4d5c9e454431dd6be729e61d0ed45acfbbf9a9b.json
+++ b/identity/.sqlx/query-9640c3953941915abca30063e4d5c9e454431dd6be729e61d0ed45acfbbf9a9b.json
@@ -1,0 +1,84 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM satellite \n            WHERE id = $1::TEXT \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9640c3953941915abca30063e4d5c9e454431dd6be729e61d0ed45acfbbf9a9b"
+}

--- a/identity/.sqlx/query-978de61807f5d04d731b483116f2f6cb4cfec91758b50bc9509af858f7ea8f3f.json
+++ b/identity/.sqlx/query-978de61807f5d04d731b483116f2f6cb4cfec91758b50bc9509af858f7ea8f3f.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE pastoral_role SET\n                name        = COALESCE($1, name),\n                description = COALESCE($2, description),\n                weight      = COALESCE($3, weight)\n            WHERE id = $4\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "978de61807f5d04d731b483116f2f6cb4cfec91758b50bc9509af858f7ea8f3f"
+}

--- a/identity/.sqlx/query-99b3d5a8088495268c33e363e92eda438874fefa56450b5d62ec6aa89e9cfc0a.json
+++ b/identity/.sqlx/query-99b3d5a8088495268c33e363e92eda438874fefa56450b5d62ec6aa89e9cfc0a.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from ministry_role WHERE id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "99b3d5a8088495268c33e363e92eda438874fefa56450b5d62ec6aa89e9cfc0a"
+}

--- a/identity/.sqlx/query-9aeb072aa1318dd36a6c53ecd78eb5284a2da7c28fb213f6494af43870c0648f.json
+++ b/identity/.sqlx/query-9aeb072aa1318dd36a6c53ecd78eb5284a2da7c28fb213f6494af43870c0648f.json
@@ -1,0 +1,166 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT \n                u.* \n            FROM \n                user_connect_group ucg\n                    INNER JOIN \"user\" u ON ucg.user_id = u.id\n            WHERE ucg.connect_group_id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "email_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "username",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "given_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "family_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "gender",
+        "type_info": {
+          "Custom": {
+            "name": "gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "ic_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "phone_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "phone_number_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "nickname",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 15,
+        "name": "date_of_birth",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "9aeb072aa1318dd36a6c53ecd78eb5284a2da7c28fb213f6494af43870c0648f"
+}

--- a/identity/.sqlx/query-a6459faad73025d4705a8b2933576d2f6d2e51d37819e7428a6536f1d12808a9.json
+++ b/identity/.sqlx/query-a6459faad73025d4705a8b2933576d2f6d2e51d37819e7428a6536f1d12808a9.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE ministry_role SET\n                name        = COALESCE($1, name),\n                description = COALESCE($2, description),\n                weight      = COALESCE($3, weight)\n            WHERE id = $4\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a6459faad73025d4705a8b2933576d2f6d2e51d37819e7428a6536f1d12808a9"
+}

--- a/identity/.sqlx/query-b13d6a5188b1704b37dc06edad4a3bc46ee2641b617721819efdc738e69a30e6.json
+++ b/identity/.sqlx/query-b13d6a5188b1704b37dc06edad4a3bc46ee2641b617721819efdc738e69a30e6.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from ministry_team WHERE id = $1::TEXT\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b13d6a5188b1704b37dc06edad4a3bc46ee2641b617721819efdc738e69a30e6"
+}

--- a/identity/.sqlx/query-b6cbb174fd9afa6f1d949e79be1cf9f79191b7aed55668321623c4ad21ac9f40.json
+++ b/identity/.sqlx/query-b6cbb174fd9afa6f1d949e79be1cf9f79191b7aed55668321623c4ad21ac9f40.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO ministry_team (\n                id, \n                name, \n                description\n            ) VALUES (\n                $1,\n                $2,\n                $3\n            ) \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b6cbb174fd9afa6f1d949e79be1cf9f79191b7aed55668321623c4ad21ac9f40"
+}

--- a/identity/.sqlx/query-b6f8a7f20bb947b6dc48cf41bf3bfb573abd67c83265bb95661940b8947c774f.json
+++ b/identity/.sqlx/query-b6f8a7f20bb947b6dc48cf41bf3bfb573abd67c83265bb95661940b8947c774f.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM connect_group \n            WHERE id = $1::TEXT \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "variant",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b6f8a7f20bb947b6dc48cf41bf3bfb573abd67c83265bb95661940b8947c774f"
+}

--- a/identity/.sqlx/query-b8d4b679916c9aed97d3660838b3c9c923b0d67d1b4f62e6c3eb49d5778f1309.json
+++ b/identity/.sqlx/query-b8d4b679916c9aed97d3660838b3c9c923b0d67d1b4f62e6c3eb49d5778f1309.json
@@ -1,0 +1,230 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO \"user\" (\n                id, \n                no, \n                name, \n                email, \n                email_verified, \n                username, \n                given_name, \n                family_name, \n                gender, \n                ic_number, \n                phone_number, \n                phone_number_verified, \n                nickname, \n                avatar_url, \n                address,\n                date_of_birth\n            ) VALUES (\n                $1, \n                $2, \n                $3, \n                $4, \n                $5, \n                $6, \n                $7, \n                $8, \n                $9, \n                $10, \n                $11, \n                $12, \n                $13, \n                $14, \n                $15,\n                $16\n            ) \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "email_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "username",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "given_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "family_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "gender",
+        "type_info": {
+          "Custom": {
+            "name": "gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "ic_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "phone_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "phone_number_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "nickname",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 15,
+        "name": "date_of_birth",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4",
+        "Text",
+        "Text",
+        "Bool",
+        "Text",
+        "Text",
+        "Text",
+        {
+          "Custom": {
+            "name": "gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female"
+              ]
+            }
+          }
+        },
+        "Text",
+        "Text",
+        "Bool",
+        "Text",
+        "Text",
+        {
+          "Custom": {
+            "name": "address",
+            "kind": {
+              "Domain": {
+                "Custom": {
+                  "name": "_address",
+                  "kind": {
+                    "Composite": [
+                      [
+                        "line_one",
+                        "Text"
+                      ],
+                      [
+                        "line_two",
+                        "Text"
+                      ],
+                      [
+                        "city",
+                        "Text"
+                      ],
+                      [
+                        "state",
+                        "Text"
+                      ],
+                      [
+                        "country",
+                        "Text"
+                      ],
+                      [
+                        "postal_code",
+                        "Text"
+                      ]
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "b8d4b679916c9aed97d3660838b3c9c923b0d67d1b4f62e6c3eb49d5778f1309"
+}

--- a/identity/.sqlx/query-bc97d616aa6668029bbe4cbf0d1c3ae804c96545940f3893960dfef7418afad5.json
+++ b/identity/.sqlx/query-bc97d616aa6668029bbe4cbf0d1c3ae804c96545940f3893960dfef7418afad5.json
@@ -1,0 +1,82 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from \"satellite\"\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "bc97d616aa6668029bbe4cbf0d1c3ae804c96545940f3893960dfef7418afad5"
+}

--- a/identity/.sqlx/query-c769c1507a48a274fdda052c172b742244f775ef8bdf561c037479d0a8fb9e71.json
+++ b/identity/.sqlx/query-c769c1507a48a274fdda052c172b742244f775ef8bdf561c037479d0a8fb9e71.json
@@ -1,0 +1,62 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE connect_group SET\n                no           = COALESCE($1, no),\n                name         = COALESCE($2, name),\n                variant      = COALESCE($3, variant),\n                satellite_id = COALESCE($4, satellite_id),\n                updated_at   = NOW()\n            WHERE id = $5\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "variant",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text",
+        "Bpchar",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c769c1507a48a274fdda052c172b742244f775ef8bdf561c037479d0a8fb9e71"
+}

--- a/identity/.sqlx/query-c9554ad470960e2c02d730cf43ef6c7166d0025a4f88af6fc28ca982d6e72ef3.json
+++ b/identity/.sqlx/query-c9554ad470960e2c02d730cf43ef6c7166d0025a4f88af6fc28ca982d6e72ef3.json
@@ -1,0 +1,166 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM \"user\" WHERE id = $1::TEXT RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "email_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "username",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "given_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "family_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "gender",
+        "type_info": {
+          "Custom": {
+            "name": "gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "ic_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "phone_number",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "phone_number_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "nickname",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "avatar_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 15,
+        "name": "date_of_birth",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "c9554ad470960e2c02d730cf43ef6c7166d0025a4f88af6fc28ca982d6e72ef3"
+}

--- a/identity/.sqlx/query-c9e33bc6c370ce738aee0d047ba49667f499df7e469abbcc098635508c2c6abf.json
+++ b/identity/.sqlx/query-c9e33bc6c370ce738aee0d047ba49667f499df7e469abbcc098635508c2c6abf.json
@@ -1,0 +1,119 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE satellite SET\n                no         = COALESCE($1, no),\n                name       = COALESCE($2, name),\n                address    = COALESCE($3, address),\n                updated_at = NOW()\n            WHERE id = $4\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "address",
+        "type_info": {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text",
+        {
+          "Custom": {
+            "name": "_address",
+            "kind": {
+              "Composite": [
+                [
+                  "line_one",
+                  "Text"
+                ],
+                [
+                  "line_two",
+                  "Text"
+                ],
+                [
+                  "city",
+                  "Text"
+                ],
+                [
+                  "state",
+                  "Text"
+                ],
+                [
+                  "country",
+                  "Text"
+                ],
+                [
+                  "postal_code",
+                  "Text"
+                ]
+              ]
+            }
+          }
+        },
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c9e33bc6c370ce738aee0d047ba49667f499df7e469abbcc098635508c2c6abf"
+}

--- a/identity/.sqlx/query-d6931b63c88341ab28f65c16872b6b449c1464da465089d13c9f7f64cb0502ee.json
+++ b/identity/.sqlx/query-d6931b63c88341ab28f65c16872b6b449c1464da465089d13c9f7f64cb0502ee.json
@@ -1,0 +1,56 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * from connect_group\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "no",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "variant",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d6931b63c88341ab28f65c16872b6b449c1464da465089d13c9f7f64cb0502ee"
+}

--- a/identity/.sqlx/query-e6218544be02e40a96607d6fe5fd6f19e28309943f9e588b620c0077781599c5.json
+++ b/identity/.sqlx/query-e6218544be02e40a96607d6fe5fd6f19e28309943f9e588b620c0077781599c5.json
@@ -1,0 +1,69 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO ministry (\n                id, \n                name, \n                description,\n                department_id,\n                team_id,\n                satellite_id\n            ) VALUES (\n                $1,\n                $2,\n                $3,\n                $4,\n                $5,\n                $6\n            ) \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "department_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "team_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "satellite_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e6218544be02e40a96607d6fe5fd6f19e28309943f9e588b620c0077781599c5"
+}

--- a/identity/.sqlx/query-eb8aef4ed215344134c3b5042e13bf7a10bd24dc7ca8945280fc870a24b2bc19.json
+++ b/identity/.sqlx/query-eb8aef4ed215344134c3b5042e13bf7a10bd24dc7ca8945280fc870a24b2bc19.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO ministry_role (\n                id, \n                name, \n                description, \n                weight\n            ) VALUES (\n                $1,\n                $2,\n                $3,\n                $4\n            ) \n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "weight",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "eb8aef4ed215344134c3b5042e13bf7a10bd24dc7ca8945280fc870a24b2bc19"
+}

--- a/identity/.sqlx/query-fb82ca8b3b945bee21fc2f96c524c075e0b53fa5e1343459c31a904f623978d9.json
+++ b/identity/.sqlx/query-fb82ca8b3b945bee21fc2f96c524c075e0b53fa5e1343459c31a904f623978d9.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM \n                user_ministry um\n            WHERE \n                um.ministry_id = $1::TEXT\n                    AND um.user_id = ANY($2::TEXT[])\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fb82ca8b3b945bee21fc2f96c524c075e0b53fa5e1343459c31a904f623978d9"
+}

--- a/identity/src/entities/mod.rs
+++ b/identity/src/entities/mod.rs
@@ -38,18 +38,18 @@ pub struct Ministry {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Object, sqlx::FromRow)]
 pub struct PastoralRole {
-    id: String,
-    name: String,
-    description: String,
-    weight: i32,
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub weight: i32,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Object, sqlx::FromRow)]
 pub struct ConnectGroup {
     pub id: String,
     pub no: i32,
-    pub name: String,
-    pub variant: String,
+    pub name: Option<String>,
+    pub variant: Option<String>,
     pub satellite_id: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,

--- a/identity/src/routes/connect_group/associate_users.rs
+++ b/identity/src/routes/connect_group/associate_users.rs
@@ -1,0 +1,112 @@
+use poem::web;
+use poem_openapi::{param::Path, payload, Object};
+use serde::{Deserialize, Serialize};
+
+use crate::{database::Database, error::ErrorResponse};
+
+#[derive(Debug, Clone, Deserialize, Serialize, Object, PartialEq, Eq, Hash)]
+#[oai(rename = "AssociateUsersWithConnectGroupRequestUser")]
+pub struct UserRole {
+    user_id: String,
+    role_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Object)]
+#[oai(rename = "AssociateUsersWithConnectGroupRequest")]
+pub struct Request {
+    #[oai(validator(min_items = 1, unique_items = true))]
+    users: Vec<UserRole>,
+}
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Response {
+    #[oai(status = 200)]
+    Ok(payload::Json<String>),
+}
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Error {
+    #[oai(status = 400)]
+    BadRequest(payload::Json<ErrorResponse>),
+
+    #[oai(status = 404)]
+    NotFound(payload::Json<ErrorResponse>),
+
+    #[oai(status = 500)]
+    InternalServer(payload::Json<ErrorResponse>),
+}
+
+impl crate::routes::Routes {
+    pub async fn _associate_users_with_connect_group(
+        &self,
+        db: web::Data<&Database>,
+        id: Path<String>,
+        body: payload::Json<Request>,
+    ) -> Result<Response, Error> {
+        sqlx::QueryBuilder::new(
+            r#"INSERT INTO user_connect_group (
+                user_id, 
+                connect_group_id, 
+                user_role
+            ) "#,
+        )
+        .push_values(&body.users, |mut b, user| {
+            b.push_bind(&user.user_id)
+                .push_bind(&*id)
+                .push_bind(&user.role_id);
+        })
+        .build()
+        .execute(&db.db)
+        .await
+        .map_err(|e| match e {
+            sqlx::Error::Database(e)
+                if e.is_unique_violation()
+                    && e.constraint()
+                        .is_some_and(|constraint| constraint == "user_connect_group_pkey") =>
+            {
+                Error::BadRequest(payload::Json(ErrorResponse {
+                    message: format!(
+                        "One of the user in the list is already associated with the connect group \
+                         '{}'",
+                        &*id
+                    ),
+                }))
+            }
+            sqlx::Error::Database(e)
+                if e.is_foreign_key_violation()
+                    && e.constraint().is_some_and(|constraint| {
+                        constraint == "user_connect_group_connect_group_id_fkey"
+                    }) =>
+            {
+                Error::BadRequest(payload::Json(ErrorResponse {
+                    message: format!("Connect group with id '{}' does not exists", &*id),
+                }))
+            }
+            sqlx::Error::Database(e)
+                if e.is_foreign_key_violation()
+                    && e.constraint().is_some_and(|constraint| {
+                        constraint == "user_connect_group_user_id_fkey"
+                    }) =>
+            {
+                Error::BadRequest(payload::Json(ErrorResponse {
+                    message: format!("One of the user in the list does not exists"),
+                }))
+            }
+            sqlx::Error::Database(e)
+                if e.is_foreign_key_violation()
+                    && e.constraint().is_some_and(|constraint| {
+                        constraint == "user_connect_group_user_role_fkey"
+                    }) =>
+            {
+                Error::BadRequest(payload::Json(ErrorResponse {
+                    message: format!("One of the role in the list does not exists"),
+                }))
+            }
+            _ => Error::InternalServer(payload::Json(ErrorResponse::from(
+                &e as &(dyn std::error::Error + Send + Sync),
+            ))),
+        })?;
+
+        Ok(Response::Ok(payload::Json("success".to_string())))
+    }
+}

--- a/identity/src/routes/connect_group/delete.rs
+++ b/identity/src/routes/connect_group/delete.rs
@@ -27,14 +27,15 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let cg: entities::ConnectGroup = sqlx::query_as(
+        let cg = sqlx::query_as!(
+            entities::ConnectGroup,
             r#"
             DELETE FROM connect_group 
             WHERE id = $1::TEXT 
             RETURNING *
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/connect_group/get.rs
+++ b/identity/src/routes/connect_group/get.rs
@@ -27,12 +27,13 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let cg: entities::ConnectGroup = sqlx::query_as(
+        let cg = sqlx::query_as!(
+            entities::ConnectGroup,
             r#"
             SELECT * from connect_group WHERE id = $1::TEXT
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/connect_group/get_users.rs
+++ b/identity/src/routes/connect_group/get_users.rs
@@ -1,0 +1,55 @@
+use poem::web;
+use poem_openapi::{param::Path, payload};
+
+use crate::{database::Database, entities, error::ErrorResponse};
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Response {
+    #[oai(status = 200)]
+    Ok(payload::Json<Vec<entities::User>>),
+}
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Error {
+    #[oai(status = 400)]
+    BadRequest(payload::Json<ErrorResponse>),
+
+    #[oai(status = 404)]
+    NotFound(payload::Json<ErrorResponse>),
+
+    #[oai(status = 500)]
+    InternalServer(payload::Json<ErrorResponse>),
+}
+
+impl crate::routes::Routes {
+    pub async fn _get_connect_group_users(
+        &self,
+        db: web::Data<&Database>,
+        id: Path<String>,
+    ) -> Result<Response, Error> {
+        let users = sqlx::query_as_unchecked!(
+            entities::User,
+            r#"
+            SELECT 
+                u.* 
+            FROM 
+                user_connect_group ucg
+                    INNER JOIN "user" u ON ucg.user_id = u.id
+            WHERE ucg.connect_group_id = $1::TEXT
+            "#,
+            &*id
+        )
+        .fetch_all(&db.db)
+        .await
+        .map_err(|e| match e {
+            sqlx::error::Error::RowNotFound => Error::NotFound(payload::Json(ErrorResponse {
+                message: format!("Connect group with id '{}' not found", &*id),
+            })),
+            _ => Error::InternalServer(payload::Json(ErrorResponse::from(
+                &e as &(dyn std::error::Error + Send + Sync),
+            ))),
+        })?;
+
+        Ok(Response::Ok(payload::Json(users)))
+    }
+}

--- a/identity/src/routes/connect_group/list.rs
+++ b/identity/src/routes/connect_group/list.rs
@@ -20,7 +20,8 @@ pub enum Error {
 
 impl crate::routes::Routes {
     pub async fn _list_connect_groups(&self, db: web::Data<&Database>) -> Result<Response, Error> {
-        let cgs: Vec<entities::ConnectGroup> = sqlx::query_as(
+        let cgs = sqlx::query_as!(
+            entities::ConnectGroup,
             r#"
             SELECT * from connect_group
             "#,

--- a/identity/src/routes/connect_group/mod.rs
+++ b/identity/src/routes/connect_group/mod.rs
@@ -1,5 +1,8 @@
+pub mod associate_users;
 pub mod create;
 pub mod delete;
 pub mod get;
+pub mod get_users;
 pub mod list;
+pub mod remove_users;
 pub mod update;

--- a/identity/src/routes/connect_group/remove_users.rs
+++ b/identity/src/routes/connect_group/remove_users.rs
@@ -1,0 +1,60 @@
+use poem::web;
+use poem_openapi::{param::Path, payload, Object};
+use serde::{Deserialize, Serialize};
+
+use crate::{database::Database, error::ErrorResponse};
+
+#[derive(Debug, Clone, Deserialize, Serialize, Object)]
+#[oai(rename = "RemoveUsersFromConnectGroupRequest")]
+pub struct Request {
+    #[oai(validator(min_items = 1, unique_items = true))]
+    users: Vec<String>,
+}
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Response {
+    #[oai(status = 200)]
+    Ok(payload::Json<String>),
+}
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Error {
+    #[oai(status = 400)]
+    BadRequest(payload::Json<ErrorResponse>),
+
+    #[oai(status = 404)]
+    NotFound(payload::Json<ErrorResponse>),
+
+    #[oai(status = 500)]
+    InternalServer(payload::Json<ErrorResponse>),
+}
+
+impl crate::routes::Routes {
+    pub async fn _remove_users_from_connect_group(
+        &self,
+        db: web::Data<&Database>,
+        id: Path<String>,
+        body: payload::Json<Request>,
+    ) -> Result<Response, Error> {
+        sqlx::query!(
+            r#"
+            DELETE FROM 
+                user_connect_group ucg
+            WHERE 
+                ucg.connect_group_id = $1::TEXT
+                    AND ucg.user_id = ANY($2::TEXT[])
+            "#,
+            &*id,
+            &body.users
+        )
+        .execute(&db.db)
+        .await
+        .map_err(|e| match e {
+            _ => Error::InternalServer(payload::Json(ErrorResponse::from(
+                &e as &(dyn std::error::Error + Send + Sync),
+            ))),
+        })?;
+
+        Ok(Response::Ok(payload::Json("success".to_string())))
+    }
+}

--- a/identity/src/routes/connect_group/update.rs
+++ b/identity/src/routes/connect_group/update.rs
@@ -39,7 +39,8 @@ impl crate::routes::Routes {
         id: Path<String>,
         body: payload::Json<Request>,
     ) -> Result<Response, Error> {
-        let cg: entities::ConnectGroup = sqlx::query_as(
+        let cg = sqlx::query_as_unchecked!(
+            entities::ConnectGroup,
             r#"
             UPDATE connect_group SET
                 no           = COALESCE($1, no),
@@ -50,12 +51,12 @@ impl crate::routes::Routes {
             WHERE id = $5
             RETURNING *
             "#,
+            &body.no,
+            &body.name,
+            &body.variant,
+            &body.satellite_id,
+            &*id,
         )
-        .bind(&body.no)
-        .bind(&body.name)
-        .bind(&body.variant)
-        .bind(&body.satellite_id)
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/ministry/associate_users.rs
+++ b/identity/src/routes/ministry/associate_users.rs
@@ -1,0 +1,109 @@
+use poem::web;
+use poem_openapi::{param::Path, payload, Object};
+use serde::{Deserialize, Serialize};
+
+use crate::{database::Database, error::ErrorResponse};
+
+#[derive(Debug, Clone, Deserialize, Serialize, Object, PartialEq, Eq, Hash)]
+#[oai(rename = "AssociateUsersWithMinistryRequestUser")]
+pub struct UserRole {
+    user_id: String,
+    role_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Object)]
+#[oai(rename = "AssociateUsersWithMinistryRequest")]
+pub struct Request {
+    #[oai(validator(min_items = 1, unique_items = true))]
+    users: Vec<UserRole>,
+}
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Response {
+    #[oai(status = 200)]
+    Ok(payload::Json<String>),
+}
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Error {
+    #[oai(status = 400)]
+    BadRequest(payload::Json<ErrorResponse>),
+
+    #[oai(status = 404)]
+    NotFound(payload::Json<ErrorResponse>),
+
+    #[oai(status = 500)]
+    InternalServer(payload::Json<ErrorResponse>),
+}
+
+impl crate::routes::Routes {
+    pub async fn _associate_users_with_ministry(
+        &self,
+        db: web::Data<&Database>,
+        id: Path<String>,
+        body: payload::Json<Request>,
+    ) -> Result<Response, Error> {
+        sqlx::QueryBuilder::new(
+            r#"INSERT INTO user_ministry (
+                user_id, 
+                ministry_id, 
+                user_role
+            ) "#,
+        )
+        .push_values(&body.users, |mut b, user| {
+            b.push_bind(&user.user_id)
+                .push_bind(&*id)
+                .push_bind(&user.role_id);
+        })
+        .build()
+        .execute(&db.db)
+        .await
+        .map_err(|e| match e {
+            sqlx::Error::Database(e)
+                if e.is_unique_violation()
+                    && e.constraint()
+                        .is_some_and(|constraint| constraint == "user_ministry_pkey") =>
+            {
+                Error::BadRequest(payload::Json(ErrorResponse {
+                    message: format!(
+                        "One of the user in the list is already associated with the ministry '{}'",
+                        &*id
+                    ),
+                }))
+            }
+            sqlx::Error::Database(e)
+                if e.is_foreign_key_violation()
+                    && e.constraint().is_some_and(|constraint| {
+                        constraint == "user_ministry_ministry_id_fkey"
+                    }) =>
+            {
+                Error::BadRequest(payload::Json(ErrorResponse {
+                    message: format!("Ministry with id '{}' does not exists", &*id),
+                }))
+            }
+            sqlx::Error::Database(e)
+                if e.is_foreign_key_violation()
+                    && e.constraint()
+                        .is_some_and(|constraint| constraint == "user_ministry_user_id_fkey") =>
+            {
+                Error::BadRequest(payload::Json(ErrorResponse {
+                    message: format!("One of the user in the list does not exists"),
+                }))
+            }
+            sqlx::Error::Database(e)
+                if e.is_foreign_key_violation()
+                    && e.constraint()
+                        .is_some_and(|constraint| constraint == "user_ministry_user_role_fkey") =>
+            {
+                Error::BadRequest(payload::Json(ErrorResponse {
+                    message: format!("One of the role in the list does not exists"),
+                }))
+            }
+            _ => Error::InternalServer(payload::Json(ErrorResponse::from(
+                &e as &(dyn std::error::Error + Send + Sync),
+            ))),
+        })?;
+
+        Ok(Response::Ok(payload::Json("success".to_string())))
+    }
+}

--- a/identity/src/routes/ministry/create.rs
+++ b/identity/src/routes/ministry/create.rs
@@ -38,7 +38,8 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         body: payload::Json<Request>,
     ) -> Result<Response, Error> {
-        let ministry: entities::Ministry = sqlx::query_as(
+        let ministry = sqlx::query_as!(
+            entities::Ministry,
             r#"
             INSERT INTO ministry (
                 id, 
@@ -46,7 +47,7 @@ impl crate::routes::Routes {
                 description,
                 department_id,
                 team_id,
-                satellite_id,
+                satellite_id
             ) VALUES (
                 $1,
                 $2,
@@ -57,13 +58,13 @@ impl crate::routes::Routes {
             ) 
             RETURNING *
             "#,
+            &format!("ministry_{}", ulid::Ulid::new()),
+            &body.name,
+            &body.description,
+            &body.department_id,
+            &body.team_id,
+            &body.satellite_id,
         )
-        .bind(&format!("ministry_{}", ulid::Ulid::new()))
-        .bind(&body.name)
-        .bind(&body.description)
-        .bind(&body.department_id)
-        .bind(&body.team_id)
-        .bind(&body.satellite_id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/ministry/delete.rs
+++ b/identity/src/routes/ministry/delete.rs
@@ -27,14 +27,15 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let ministry: entities::Ministry = sqlx::query_as(
+        let ministry = sqlx::query_as!(
+            entities::Ministry,
             r#"
             DELETE FROM ministry 
             WHERE id = $1::TEXT 
             RETURNING *
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/ministry/get.rs
+++ b/identity/src/routes/ministry/get.rs
@@ -27,12 +27,13 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let ministry: entities::Ministry = sqlx::query_as(
+        let ministry = sqlx::query_as!(
+            entities::Ministry,
             r#"
             SELECT * from ministry WHERE id = $1::TEXT
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/ministry/get_users.rs
+++ b/identity/src/routes/ministry/get_users.rs
@@ -1,0 +1,55 @@
+use poem::web;
+use poem_openapi::{param::Path, payload};
+
+use crate::{database::Database, entities, error::ErrorResponse};
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Response {
+    #[oai(status = 200)]
+    Ok(payload::Json<Vec<entities::User>>),
+}
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Error {
+    #[oai(status = 400)]
+    BadRequest(payload::Json<ErrorResponse>),
+
+    #[oai(status = 404)]
+    NotFound(payload::Json<ErrorResponse>),
+
+    #[oai(status = 500)]
+    InternalServer(payload::Json<ErrorResponse>),
+}
+
+impl crate::routes::Routes {
+    pub async fn _get_ministry_users(
+        &self,
+        db: web::Data<&Database>,
+        id: Path<String>,
+    ) -> Result<Response, Error> {
+        let users = sqlx::query_as_unchecked!(
+            entities::User,
+            r#"
+            SELECT 
+                u.* 
+            FROM 
+                user_ministry um
+                    INNER JOIN "user" u ON um.user_id = u.id
+            WHERE um.ministry_id = $1::TEXT
+            "#,
+            &*id
+        )
+        .fetch_all(&db.db)
+        .await
+        .map_err(|e| match e {
+            sqlx::error::Error::RowNotFound => Error::NotFound(payload::Json(ErrorResponse {
+                message: format!("Ministry with id '{}' not found", &*id),
+            })),
+            _ => Error::InternalServer(payload::Json(ErrorResponse::from(
+                &e as &(dyn std::error::Error + Send + Sync),
+            ))),
+        })?;
+
+        Ok(Response::Ok(payload::Json(users)))
+    }
+}

--- a/identity/src/routes/ministry/list.rs
+++ b/identity/src/routes/ministry/list.rs
@@ -20,7 +20,8 @@ pub enum Error {
 
 impl crate::routes::Routes {
     pub async fn _list_ministries(&self, db: web::Data<&Database>) -> Result<Response, Error> {
-        let ministries: Vec<entities::Ministry> = sqlx::query_as(
+        let ministries = sqlx::query_as!(
+            entities::Ministry,
             r#"
             SELECT * from ministry
             "#,

--- a/identity/src/routes/ministry/mod.rs
+++ b/identity/src/routes/ministry/mod.rs
@@ -1,4 +1,8 @@
+pub mod associate_users;
 pub mod create;
 pub mod delete;
 pub mod get;
+pub mod get_users;
 pub mod list;
+pub mod remove_users;
+pub mod update;

--- a/identity/src/routes/ministry/remove_users.rs
+++ b/identity/src/routes/ministry/remove_users.rs
@@ -1,0 +1,60 @@
+use poem::web;
+use poem_openapi::{param::Path, payload, Object};
+use serde::{Deserialize, Serialize};
+
+use crate::{database::Database, error::ErrorResponse};
+
+#[derive(Debug, Clone, Deserialize, Serialize, Object)]
+#[oai(rename = "RemoveUsersFromMinistryRequest")]
+pub struct Request {
+    #[oai(validator(min_items = 1, unique_items = true))]
+    users: Vec<String>,
+}
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Response {
+    #[oai(status = 200)]
+    Ok(payload::Json<String>),
+}
+
+#[derive(poem_openapi::ApiResponse)]
+pub enum Error {
+    #[oai(status = 400)]
+    BadRequest(payload::Json<ErrorResponse>),
+
+    #[oai(status = 404)]
+    NotFound(payload::Json<ErrorResponse>),
+
+    #[oai(status = 500)]
+    InternalServer(payload::Json<ErrorResponse>),
+}
+
+impl crate::routes::Routes {
+    pub async fn _remove_users_from_ministry(
+        &self,
+        db: web::Data<&Database>,
+        id: Path<String>,
+        body: payload::Json<Request>,
+    ) -> Result<Response, Error> {
+        sqlx::query!(
+            r#"
+            DELETE FROM 
+                user_ministry um
+            WHERE 
+                um.ministry_id = $1::TEXT
+                    AND um.user_id = ANY($2::TEXT[])
+            "#,
+            &*id,
+            &body.users
+        )
+        .execute(&db.db)
+        .await
+        .map_err(|e| match e {
+            _ => Error::InternalServer(payload::Json(ErrorResponse::from(
+                &e as &(dyn std::error::Error + Send + Sync),
+            ))),
+        })?;
+
+        Ok(Response::Ok(payload::Json("success".to_string())))
+    }
+}

--- a/identity/src/routes/ministry_department/create.rs
+++ b/identity/src/routes/ministry_department/create.rs
@@ -35,7 +35,8 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         body: payload::Json<Request>,
     ) -> Result<Response, Error> {
-        let ministry_department: entities::MinistryDepartment = sqlx::query_as(
+        let ministry_department = sqlx::query_as!(
+            entities::MinistryDepartment,
             r#"
             INSERT INTO ministry_department (
                 id, 
@@ -44,14 +45,14 @@ impl crate::routes::Routes {
             ) VALUES (
                 $1,
                 $2,
-                $3,
+                $3
             ) 
             RETURNING *
             "#,
+            &format!("ministry_department_{}", ulid::Ulid::new()),
+            &body.name,
+            &body.description,
         )
-        .bind(&format!("ministry_department_{}", ulid::Ulid::new()))
-        .bind(&body.name)
-        .bind(&body.description)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {
@@ -63,4 +64,3 @@ impl crate::routes::Routes {
         Ok(Response::Ok(payload::Json(ministry_department)))
     }
 }
-

--- a/identity/src/routes/ministry_department/delete.rs
+++ b/identity/src/routes/ministry_department/delete.rs
@@ -27,14 +27,15 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let ministry_department: entities::MinistryDepartment = sqlx::query_as(
+        let ministry_department = sqlx::query_as!(
+            entities::MinistryDepartment,
             r#"
             DELETE FROM ministry_department 
             WHERE id = $1::TEXT 
             RETURNING *
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/ministry_department/get.rs
+++ b/identity/src/routes/ministry_department/get.rs
@@ -27,12 +27,13 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let ministry_department: entities::MinistryDepartment = sqlx::query_as(
+        let ministry_department = sqlx::query_as!(
+            entities::MinistryDepartment,
             r#"
             SELECT * from ministry_department WHERE id = $1::TEXT
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {
@@ -47,3 +48,4 @@ impl crate::routes::Routes {
         Ok(Response::Ok(payload::Json(ministry_department)))
     }
 }
+

--- a/identity/src/routes/ministry_department/list.rs
+++ b/identity/src/routes/ministry_department/list.rs
@@ -19,8 +19,12 @@ pub enum Error {
 }
 
 impl crate::routes::Routes {
-    pub async fn _list_ministry_department(&self, db: web::Data<&Database>) -> Result<Response, Error> {
-        let ministry_departments: Vec<entities::MinistryDepartment> = sqlx::query_as(
+    pub async fn _list_ministry_department(
+        &self,
+        db: web::Data<&Database>,
+    ) -> Result<Response, Error> {
+        let ministry_departments = sqlx::query_as!(
+            entities::MinistryDepartment,
             r#"
             SELECT * from ministry_department
             "#,

--- a/identity/src/routes/ministry_role/create.rs
+++ b/identity/src/routes/ministry_role/create.rs
@@ -73,7 +73,8 @@ impl crate::routes::Routes {
             })))?
             .to_string();
 
-        let ministry_role: entities::MinistryRole = sqlx::query_as(
+        let ministry_role = sqlx::query_as!(
+            entities::MinistryRole,
             r#"
             INSERT INTO ministry_role (
                 id, 
@@ -88,11 +89,11 @@ impl crate::routes::Routes {
             ) 
             RETURNING *
             "#,
+            &role_id,
+            &body.name,
+            &body.description,
+            &body.weight,
         )
-        .bind(&role_id)
-        .bind(&body.name)
-        .bind(&body.description)
-        .bind(&body.weight)
         .fetch_one(&mut *tx)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/ministry_role/delete.rs
+++ b/identity/src/routes/ministry_role/delete.rs
@@ -60,14 +60,15 @@ impl crate::routes::Routes {
             }
         };
 
-        let ministry_role: entities::MinistryRole = sqlx::query_as(
+        let ministry_role = sqlx::query_as!(
+            entities::MinistryRole,
             r#"
             DELETE FROM ministry_role 
             WHERE id = $1::TEXT 
             RETURNING *
             "#,
+            &*id,
         )
-        .bind(&*id)
         .fetch_one(&mut *tx)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/ministry_role/get.rs
+++ b/identity/src/routes/ministry_role/get.rs
@@ -27,12 +27,13 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let ministry_role: entities::MinistryRole = sqlx::query_as(
+        let ministry_role = sqlx::query_as!(
+            entities::MinistryRole,
             r#"
             SELECT * from ministry_role WHERE id = $1::TEXT
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/ministry_role/list.rs
+++ b/identity/src/routes/ministry_role/list.rs
@@ -20,7 +20,8 @@ pub enum Error {
 
 impl crate::routes::Routes {
     pub async fn _list_ministry_roles(&self, db: web::Data<&Database>) -> Result<Response, Error> {
-        let ministry_roles: Vec<entities::MinistryRole> = sqlx::query_as(
+        let ministry_roles = sqlx::query_as!(
+            entities::MinistryRole,
             r#"
             SELECT * from ministry_role
             "#,
@@ -36,4 +37,3 @@ impl crate::routes::Routes {
         Ok(Response::Ok(payload::Json(ministry_roles)))
     }
 }
-

--- a/identity/src/routes/ministry_role/update.rs
+++ b/identity/src/routes/ministry_role/update.rs
@@ -71,20 +71,21 @@ impl crate::routes::Routes {
             }
         };
 
-        let ministry_role: entities::MinistryRole = sqlx::query_as(
+        let ministry_role = sqlx::query_as_unchecked!(
+            entities::MinistryRole,
             r#"
-            UPDATE connect_group SET
-                name         = COALESCE($1, name),
-                description  = COALESCE($2, description),
-                weight       = COALESCE($3, weight),
+            UPDATE ministry_role SET
+                name        = COALESCE($1, name),
+                description = COALESCE($2, description),
+                weight      = COALESCE($3, weight)
             WHERE id = $4
             RETURNING *
             "#,
+            &body.name,
+            &body.description,
+            &body.weight,
+            &*id,
         )
-        .bind(&body.name)
-        .bind(&body.description)
-        .bind(&body.weight)
-        .bind(&*id)
         .fetch_one(&mut *tx)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/ministry_team/create.rs
+++ b/identity/src/routes/ministry_team/create.rs
@@ -35,23 +35,24 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         body: payload::Json<Request>,
     ) -> Result<Response, Error> {
-        let ministry_team: entities::MinistryTeam = sqlx::query_as(
+        let ministry_team = sqlx::query_as!(
+            entities::MinistryTeam,
             r#"
             INSERT INTO ministry_team (
                 id, 
                 name, 
-                description,
+                description
             ) VALUES (
                 $1,
                 $2,
-                $3,
+                $3
             ) 
             RETURNING *
             "#,
+            &format!("ministry_team_{}", ulid::Ulid::new()),
+            &body.name,
+            &body.description,
         )
-        .bind(&format!("ministry_team_{}", ulid::Ulid::new()))
-        .bind(&body.name)
-        .bind(&body.description)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {
@@ -63,3 +64,4 @@ impl crate::routes::Routes {
         Ok(Response::Ok(payload::Json(ministry_team)))
     }
 }
+

--- a/identity/src/routes/ministry_team/delete.rs
+++ b/identity/src/routes/ministry_team/delete.rs
@@ -27,14 +27,15 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let ministry_team: entities::MinistryTeam = sqlx::query_as(
+        let ministry_team = sqlx::query_as!(
+            entities::MinistryTeam,
             r#"
             DELETE FROM ministry_team 
             WHERE id = $1::TEXT 
             RETURNING *
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {
@@ -49,3 +50,4 @@ impl crate::routes::Routes {
         Ok(Response::Ok(payload::Json(ministry_team)))
     }
 }
+

--- a/identity/src/routes/ministry_team/get.rs
+++ b/identity/src/routes/ministry_team/get.rs
@@ -27,12 +27,13 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let ministry_team: entities::MinistryTeam = sqlx::query_as(
+        let ministry_team = sqlx::query_as!(
+            entities::MinistryTeam,
             r#"
             SELECT * from ministry_team WHERE id = $1::TEXT
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {
@@ -47,3 +48,4 @@ impl crate::routes::Routes {
         Ok(Response::Ok(payload::Json(ministry_team)))
     }
 }
+

--- a/identity/src/routes/ministry_team/list.rs
+++ b/identity/src/routes/ministry_team/list.rs
@@ -20,7 +20,8 @@ pub enum Error {
 
 impl crate::routes::Routes {
     pub async fn _list_ministry_team(&self, db: web::Data<&Database>) -> Result<Response, Error> {
-        let ministry_teams: Vec<entities::MinistryTeam> = sqlx::query_as(
+        let ministry_teams = sqlx::query_as!(
+            entities::MinistryTeam,
             r#"
             SELECT * from ministry_team
             "#,

--- a/identity/src/routes/ministry_team/update.rs
+++ b/identity/src/routes/ministry_team/update.rs
@@ -36,19 +36,20 @@ impl crate::routes::Routes {
         id: Path<String>,
         body: payload::Json<Request>,
     ) -> Result<Response, Error> {
-        let ministry_team: entities::MinistryTeam = sqlx::query_as(
+        let ministry_team = sqlx::query_as_unchecked!(
+            entities::MinistryTeam,
             r#"
             UPDATE ministry_team SET
-                name         = COALESCE($1, name),
-                description  = COALESCE($2, description)
-                updated_at   = NOW()
+                name        = COALESCE($1, name),
+                description = COALESCE($2, description),
+                updated_at  = NOW()
             WHERE id = $3
             RETURNING *
             "#,
+            &body.name,
+            &body.description,
+            &*id,
         )
-        .bind(&body.name)
-        .bind(&body.description)
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/mod.rs
+++ b/identity/src/routes/mod.rs
@@ -393,9 +393,12 @@ impl Routes {
     )]
     async fn associate_users_with_connect_group(
         &self,
+        db: web::Data<&Database>,
         id: Path<String>,
-    ) -> payload::PlainText<String> {
-        payload::PlainText("unimplemented".to_string())
+        body: payload::Json<connect_group::associate_users::Request>,
+    ) -> Result<connect_group::associate_users::Response, connect_group::associate_users::Error>
+    {
+        self._associate_users_with_connect_group(db, id, body).await
     }
 
     /// Get connect group users
@@ -407,8 +410,12 @@ impl Routes {
         operation_id = "get-connect-group-users",
         tag = "Tag::ConnectGroup"
     )]
-    async fn get_connect_group_users(&self, id: Path<String>) -> payload::PlainText<String> {
-        payload::PlainText("unimplemented".to_string())
+    async fn get_connect_group_users(
+        &self,
+        db: web::Data<&Database>,
+        id: Path<String>,
+    ) -> Result<connect_group::get_users::Response, connect_group::get_users::Error> {
+        self._get_connect_group_users(db, id).await
     }
 
     /// Remove users from a connect group
@@ -422,9 +429,11 @@ impl Routes {
     )]
     async fn remove_users_from_connect_group(
         &self,
+        db: web::Data<&Database>,
         id: Path<String>,
-    ) -> payload::PlainText<String> {
-        payload::PlainText("unimplemented".to_string())
+        body: payload::Json<connect_group::remove_users::Request>,
+    ) -> Result<connect_group::remove_users::Response, connect_group::remove_users::Error> {
+        self._remove_users_from_connect_group(db, id, body).await
     }
 
     /* Pastoral Roles */
@@ -835,8 +844,13 @@ impl Routes {
         operation_id = "update-ministry",
         tag = "Tag::Ministry"
     )]
-    async fn update_ministry(&self, id: Path<String>) -> payload::PlainText<String> {
-        payload::PlainText("unimplemented".to_string())
+    async fn update_ministry(
+        &self,
+        db: web::Data<&Database>,
+        id: Path<String>,
+        body: payload::Json<ministry::update::Request>,
+    ) -> Result<ministry::update::Response, ministry::update::Error> {
+        self._update_ministry(db, id, body).await
     }
 
     /// Delete a ministry
@@ -865,8 +879,13 @@ impl Routes {
         operation_id = "associate-users-with-ministry",
         tag = "Tag::Ministry"
     )]
-    async fn associate_users_with_ministry(&self, id: Path<String>) -> payload::PlainText<String> {
-        payload::PlainText("unimplemented".to_string())
+    async fn associate_users_with_ministry(
+        &self,
+        db: web::Data<&Database>,
+        id: Path<String>,
+        body: payload::Json<ministry::associate_users::Request>,
+    ) -> Result<ministry::associate_users::Response, ministry::associate_users::Error> {
+        self._associate_users_with_ministry(db, id, body).await
     }
 
     /// Get users associated with a ministry
@@ -878,8 +897,12 @@ impl Routes {
         operation_id = "get-ministry-users",
         tag = "Tag::Ministry"
     )]
-    async fn get_ministry_users(&self, id: Path<String>) -> payload::PlainText<String> {
-        payload::PlainText("unimplemented".to_string())
+    async fn get_ministry_users(
+        &self,
+        db: web::Data<&Database>,
+        id: Path<String>,
+    ) -> Result<ministry::get_users::Response, ministry::get_users::Error> {
+        self._get_ministry_users(db, id).await
     }
 
     /// Remove users from a ministry
@@ -891,7 +914,12 @@ impl Routes {
         operation_id = "remove-users-from-ministry",
         tag = "Tag::Ministry"
     )]
-    async fn remove_users_from_ministry(&self, id: Path<String>) -> payload::PlainText<String> {
-        payload::PlainText("unimplemented".to_string())
+    async fn remove_users_from_ministry(
+        &self,
+        db: web::Data<&Database>,
+        id: Path<String>,
+        body: payload::Json<ministry::remove_users::Request>,
+    ) -> Result<ministry::remove_users::Response, ministry::remove_users::Error> {
+        self._remove_users_from_ministry(db, id, body).await
     }
 }

--- a/identity/src/routes/pastoral_role/create.rs
+++ b/identity/src/routes/pastoral_role/create.rs
@@ -73,7 +73,8 @@ impl crate::routes::Routes {
             })))?
             .to_string();
 
-        let pr: entities::PastoralRole = sqlx::query_as(
+        let pr = sqlx::query_as!(
+            entities::PastoralRole,
             r#"
             INSERT INTO pastoral_role (
                 id, 
@@ -88,11 +89,11 @@ impl crate::routes::Routes {
             ) 
             RETURNING *
             "#,
+            &role_id,
+            &body.name,
+            &body.description,
+            &body.weight,
         )
-        .bind(&role_id)
-        .bind(&body.name)
-        .bind(&body.description)
-        .bind(&body.weight)
         .fetch_one(&mut *tx)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/pastoral_role/delete.rs
+++ b/identity/src/routes/pastoral_role/delete.rs
@@ -60,14 +60,15 @@ impl crate::routes::Routes {
             }
         };
 
-        let pr: entities::PastoralRole = sqlx::query_as(
+        let pr = sqlx::query_as!(
+            entities::PastoralRole,
             r#"
             DELETE FROM pastoral_role 
             WHERE id = $1::TEXT 
             RETURNING *
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&mut *tx)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/pastoral_role/get.rs
+++ b/identity/src/routes/pastoral_role/get.rs
@@ -27,12 +27,13 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let pr: entities::PastoralRole = sqlx::query_as(
+        let pr = sqlx::query_as!(
+            entities::PastoralRole,
             r#"
             SELECT * from pastoral_role WHERE id = $1::TEXT
             "#,
+            &*id,
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/pastoral_role/list.rs
+++ b/identity/src/routes/pastoral_role/list.rs
@@ -20,7 +20,8 @@ pub enum Error {
 
 impl crate::routes::Routes {
     pub async fn _list_pastoral_roles(&self, db: web::Data<&Database>) -> Result<Response, Error> {
-        let prs: Vec<entities::PastoralRole> = sqlx::query_as(
+        let prs = sqlx::query_as!(
+            entities::PastoralRole,
             r#"
             SELECT * from pastoral_role
             "#,

--- a/identity/src/routes/pastoral_role/update.rs
+++ b/identity/src/routes/pastoral_role/update.rs
@@ -71,20 +71,21 @@ impl crate::routes::Routes {
             }
         };
 
-        let pr: entities::PastoralRole = sqlx::query_as(
+        let pr = sqlx::query_as_unchecked!(
+            entities::PastoralRole,
             r#"
             UPDATE pastoral_role SET
-                name           = COALESCE($1, name),
-                description    = COALESCE($2, description),
-                weight         = COALESCE($3, weight)
+                name        = COALESCE($1, name),
+                description = COALESCE($2, description),
+                weight      = COALESCE($3, weight)
             WHERE id = $4
             RETURNING *
             "#,
+            &body.name,
+            &body.description,
+            &body.weight,
+            &*id,
         )
-        .bind(&body.name)
-        .bind(&body.description)
-        .bind(&body.weight)
-        .bind(&*id)
         .fetch_one(&mut *tx)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/satellite/delete.rs
+++ b/identity/src/routes/satellite/delete.rs
@@ -27,14 +27,15 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let satellite: entities::Satellite = sqlx::query_as(
+        let satellite = sqlx::query_as_unchecked!(
+            entities::Satellite,
             r#"
             DELETE FROM satellite 
             WHERE id = $1::TEXT 
             RETURNING *
             "#,
+            &*id,
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/satellite/list.rs
+++ b/identity/src/routes/satellite/list.rs
@@ -20,7 +20,8 @@ pub enum Error {
 
 impl crate::routes::Routes {
     pub async fn _list_satellites(&self, db: web::Data<&Database>) -> Result<Response, Error> {
-        let satellites: Vec<entities::Satellite> = sqlx::query_as(
+        let satellites = sqlx::query_as_unchecked!(
+            entities::Satellite,
             r#"
             SELECT * from "satellite"
             "#,

--- a/identity/src/routes/users/create.rs
+++ b/identity/src/routes/users/create.rs
@@ -83,7 +83,8 @@ impl crate::routes::Routes {
                 $14, 
                 $15,
                 $16
-            ) RETURNING *
+            ) 
+            RETURNING *
             "#,
             &body.id,
             &body.no,

--- a/identity/src/routes/users/delete.rs
+++ b/identity/src/routes/users/delete.rs
@@ -27,12 +27,13 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let user: entities::User = sqlx::query_as(
+        let user = sqlx::query_as_unchecked!(
+            entities::User,
             r#"
-            DELETE from "user" WHERE id = $1::TEXT RETURNING *
+            DELETE FROM "user" WHERE id = $1::TEXT RETURNING *
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/users/get.rs
+++ b/identity/src/routes/users/get.rs
@@ -27,12 +27,13 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let user: entities::User = sqlx::query_as(
+        let user = sqlx::query_as_unchecked!(
+            entities::User,
             r#"
             SELECT * from "user" WHERE id = $1::TEXT
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/users/get_connect_groups.rs
+++ b/identity/src/routes/users/get_connect_groups.rs
@@ -27,7 +27,8 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let cgs: Vec<entities::ConnectGroup> = sqlx::query_as(
+        let cgs = sqlx::query_as!(
+            entities::ConnectGroup,
             r#"
             SELECT 
                 cg.* 
@@ -36,8 +37,8 @@ impl crate::routes::Routes {
                     INNER JOIN user_connect_group ucg ON cg.id = ucg.connect_group_id
             WHERE ucg.user_id = $1::TEXT
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_all(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/users/get_ministries.rs
+++ b/identity/src/routes/users/get_ministries.rs
@@ -27,7 +27,8 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let ministries: Vec<entities::Ministry> = sqlx::query_as(
+        let ministries = sqlx::query_as!(
+            entities::Ministry,
             r#"
             SELECT 
                 m.* 
@@ -36,8 +37,8 @@ impl crate::routes::Routes {
                     INNER JOIN user_ministry um ON m.id = um.ministry_id
             WHERE um.user_id = $1::TEXT
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_all(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/users/get_ministry_roles.rs
+++ b/identity/src/routes/users/get_ministry_roles.rs
@@ -27,7 +27,8 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let roles: Vec<entities::MinistryRole> = sqlx::query_as(
+        let roles = sqlx::query_as!(
+            entities::MinistryRole,
             r#"
             SELECT 
                 mr.* 
@@ -36,8 +37,8 @@ impl crate::routes::Routes {
                     INNER JOIN user_ministry um ON mr.id = um.user_role
             WHERE um.user_id = $1::TEXT
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_all(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/users/get_pastoral_roles.rs
+++ b/identity/src/routes/users/get_pastoral_roles.rs
@@ -27,7 +27,8 @@ impl crate::routes::Routes {
         db: web::Data<&Database>,
         id: Path<String>,
     ) -> Result<Response, Error> {
-        let roles: Vec<entities::PastoralRole> = sqlx::query_as(
+        let roles = sqlx::query_as!(
+            entities::PastoralRole,
             r#"
             SELECT 
                 pr.* 
@@ -36,8 +37,8 @@ impl crate::routes::Routes {
                     INNER JOIN user_connect_group ucg ON pr.id = ucg.user_role
             WHERE ucg.user_id = $1::TEXT
             "#,
+            &*id
         )
-        .bind(&*id)
         .fetch_all(&db.db)
         .await
         .map_err(|e| match e {

--- a/identity/src/routes/users/list.rs
+++ b/identity/src/routes/users/list.rs
@@ -20,7 +20,8 @@ pub enum Error {
 
 impl crate::routes::Routes {
     pub async fn _list_users(&self, db: web::Data<&Database>) -> Result<Response, Error> {
-        let users: Vec<entities::User> = sqlx::query_as(
+        let users = sqlx::query_as_unchecked!(
+            entities::User,
             r#"
             SELECT * from "user"
             "#,

--- a/identity/src/routes/users/update.rs
+++ b/identity/src/routes/users/update.rs
@@ -50,7 +50,8 @@ impl crate::routes::Routes {
         id: Path<String>,
         body: payload::Json<Request>,
     ) -> Result<Response, Error> {
-        let user: entities::User = sqlx::query_as(
+        let user = sqlx::query_as_unchecked!(
+            entities::User,
             r#"
             UPDATE "user" SET  
                 name                  = COALESCE($1, name),
@@ -68,24 +69,25 @@ impl crate::routes::Routes {
                 address               = COALESCE($13, address),
                 date_of_birth         = COALESCE($14, date_of_birth),
                 updated_at            = NOW()
-            WHERE id = $15 RETURNING *
+            WHERE id = $15
+            RETURNING *
             "#,
+            &body.name,
+            &body.email,
+            &body.email_verified,
+            &body.username,
+            &body.given_name,
+            &body.family_name,
+            &body.gender,
+            &body.ic_number,
+            &body.phone_number,
+            &body.phone_number_verified,
+            &body.nickname,
+            &body.avatar_url,
+            &body.address,
+            &body.date_of_birth,
+            &*id,
         )
-        .bind(&body.name)
-        .bind(&body.email)
-        .bind(&body.email_verified)
-        .bind(&body.username)
-        .bind(&body.given_name)
-        .bind(&body.family_name)
-        .bind(&body.gender)
-        .bind(&body.ic_number)
-        .bind(&body.phone_number)
-        .bind(&body.phone_number_verified)
-        .bind(&body.nickname)
-        .bind(&body.avatar_url)
-        .bind(&body.address)
-        .bind(&body.date_of_birth)
-        .bind(&*id)
         .fetch_one(&db.db)
         .await
         .map_err(|e| match e {


### PR DESCRIPTION
### Please tell us what you did
1. change `query()` and `query_as()` to use sqlx macros, so that our queries are checked at compile time for SQL syntax error.
2. finished up remaining endpoints

### Are there any concerns that may be raised ?
These endpoints are not tested yet but they should be working.


### Please add which issue does this PR close below using ("closes #issue_number")

Close #5 and #10 