### PR TITLE
feat: removed AUTH0_CONNECTION as an env

### DIFF
--- a/identity/src/config.rs
+++ b/identity/src/config.rs
@@ -37,8 +37,4 @@ pub struct Config {
     /// The client secret for Auth0 app.
     #[clap(long, env)]
     pub auth0_client_secret: String,
-
-    /// The name of the database connection for Auth0 app.
-    #[clap(long, env)]
-    pub auth0_connection: String,
 }


### PR DESCRIPTION
### Please tell us what you did
1. removed `AUTH0_CONNECTION` as an environment variable in Identity API
2.
3.
4.

### Are there any concerns that may be raised ?



### Please add which issue does this PR close below using ("closes #issue_number")