### PR TITLE
feat: added error handling for create role auth0

### DIFF
--- a/identity/src/routes/ministry_role/create.rs
+++ b/identity/src/routes/ministry_role/create.rs
@@ -56,6 +56,14 @@ impl crate::routes::Routes {
                     &e as &(dyn std::error::Error + Send + Send + Sync),
                 )))
             })?
+            .error_for_status()
+            .map_err(|e| {
+                tracing::error!("Failed to create role: {}", e);
+
+                Error::InternalServer(payload::Json(ErrorResponse::from(
+                    &e as &(dyn std::error::Error + Send + Send + Sync),
+                )))
+            })?
             .json::<serde_json::Value>()
             .await
             .map_err(|e| {

--- a/identity/src/routes/pastoral_role/create.rs
+++ b/identity/src/routes/pastoral_role/create.rs
@@ -56,6 +56,14 @@ impl crate::routes::Routes {
                     &e as &(dyn std::error::Error + Send + Send + Sync),
                 )))
             })?
+            .error_for_status()
+            .map_err(|e| {
+                tracing::error!("Failed to create role: {}", e);
+
+                Error::InternalServer(payload::Json(ErrorResponse::from(
+                    &e as &(dyn std::error::Error + Send + Send + Sync),
+                )))
+            })?
             .json::<serde_json::Value>()
             .await
             .map_err(|e| {


### PR DESCRIPTION
### Please tell us what you did
1. Added `error_for_status()` for create_role calls to Auth0's Management API
2. Added tracing::error when there is an error response
3.
4.

### Are there any concerns that may be raised ?
The error handling for the entire codebase is not perfect yet, but it will work for the time being.

### Please add which issue does this PR close below using ("closes #issue_number")
No