### PR TITLE
Allow reassigning connect group roles

### DIFF
--- a/identity/src/routes/connect_group/associate_users.rs
+++ b/identity/src/routes/connect_group/associate_users.rs
@@ -48,7 +48,7 @@ impl crate::routes::Routes {
                 user_id, 
                 connect_group_id, 
                 user_role
-            )"#,
+            ) "#,
         )
         .push_values(&body.users, |mut b, user| {
             b.push_bind(&user.user_id)

--- a/identity/src/routes/connect_group/associate_users.rs
+++ b/identity/src/routes/connect_group/associate_users.rs
@@ -48,7 +48,14 @@ impl crate::routes::Routes {
                 user_id, 
                 connect_group_id, 
                 user_role
-            ) "#,
+			) VALUES (
+				$1,
+				$2,
+				$3
+			)
+				ON CONFLICT (user_id, connect_group_id) DO UPDATE
+					SET user_role = EXCLUDED.user_role
+            "#,
         )
         .push_values(&body.users, |mut b, user| {
             b.push_bind(&user.user_id)

--- a/identity/src/routes/connect_group/associate_users.rs
+++ b/identity/src/routes/connect_group/associate_users.rs
@@ -48,20 +48,15 @@ impl crate::routes::Routes {
                 user_id, 
                 connect_group_id, 
                 user_role
-			) VALUES (
-				$1,
-				$2,
-				$3
-			)
-				ON CONFLICT (user_id, connect_group_id) DO UPDATE
-					SET user_role = EXCLUDED.user_role
-            "#,
+            )"#,
         )
         .push_values(&body.users, |mut b, user| {
             b.push_bind(&user.user_id)
                 .push_bind(&*id)
                 .push_bind(&user.role_id);
         })
+        .push("ON CONFLICT (user_id, connect_group_id) DO UPDATE 
+                        SET user_role = EXCLUDED.user_role")
         .build()
         .execute(&db.db)
         .await


### PR DESCRIPTION
When reassigning an existing user in a connect group with a new role, the role will be replaced instead of going into error.