### PR TITLE
Allow reassigning ministry roles

### DIFF
--- a/identity/src/main.rs
+++ b/identity/src/main.rs
@@ -10,12 +10,12 @@ use poem_openapi::{payload, LicenseObject, OpenApiService};
 
 use crate::config::Config;
 
+mod auth;
 mod config;
 mod database;
 mod entities;
 mod error;
 mod routes;
-mod auth;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {

--- a/identity/src/routes/connect_group/associate_users.rs
+++ b/identity/src/routes/connect_group/associate_users.rs
@@ -56,7 +56,7 @@ impl crate::routes::Routes {
                 .push_bind(&user.role_id);
         })
         .push(
-            "ON CONFLICT (user_id, connect_group_id) DO UPDATE 
+            " ON CONFLICT (user_id, connect_group_id) DO UPDATE 
                         SET user_role = EXCLUDED.user_role",
         )
         .build()

--- a/identity/src/routes/connect_group/associate_users.rs
+++ b/identity/src/routes/connect_group/associate_users.rs
@@ -55,8 +55,10 @@ impl crate::routes::Routes {
                 .push_bind(&*id)
                 .push_bind(&user.role_id);
         })
-        .push("ON CONFLICT (user_id, connect_group_id) DO UPDATE 
-                        SET user_role = EXCLUDED.user_role")
+        .push(
+            "ON CONFLICT (user_id, connect_group_id) DO UPDATE 
+                        SET user_role = EXCLUDED.user_role",
+        )
         .build()
         .execute(&db.db)
         .await

--- a/identity/src/routes/ministry/associate_users.rs
+++ b/identity/src/routes/ministry/associate_users.rs
@@ -55,6 +55,8 @@ impl crate::routes::Routes {
                 .push_bind(&*id)
                 .push_bind(&user.role_id);
         })
+		.push("ON CONFLICT (user_id, ministry_id) DO UPDATE
+						SET user_role = EXCLUDED.user_role")
         .build()
         .execute(&db.db)
         .await

--- a/identity/src/routes/ministry/associate_users.rs
+++ b/identity/src/routes/ministry/associate_users.rs
@@ -55,8 +55,10 @@ impl crate::routes::Routes {
                 .push_bind(&*id)
                 .push_bind(&user.role_id);
         })
-		.push("ON CONFLICT (user_id, ministry_id) DO UPDATE
-						SET user_role = EXCLUDED.user_role")
+        .push(
+            " ON CONFLICT (user_id, ministry_id) DO UPDATE
+						SET user_role = EXCLUDED.user_role",
+        )
         .build()
         .execute(&db.db)
         .await

--- a/identity/src/routes/mod.rs
+++ b/identity/src/routes/mod.rs
@@ -1,7 +1,7 @@
 use poem::web;
 use poem_openapi::{param::Path, payload, OpenApi, Tags};
 
-use crate::{database::Database, auth::BearerAuth};
+use crate::{auth::BearerAuth, database::Database};
 
 mod connect_group;
 mod ministry;


### PR DESCRIPTION
When reassigning an existing user in ministry with a new role, the role will be replaced instead of going into error.